### PR TITLE
Fix: Skip unwanted levels in the tree view

### DIFF
--- a/client/src/components/UnitPicker.js
+++ b/client/src/components/UnitPicker.js
@@ -43,9 +43,15 @@ const UnitPicker = ({ selectedUnits, setSelectedUnits }) => {
   }, []);
 
   const onNodeToggle = async (node) => {
-    if (!node.children || node.children.length === 0) {
-      const response = await axios.get(`${API_URL}/units?level=${node.level + 1}&parentId=${node.id}`);
-      const children = response.data.results.map(child => ({ ...child, level: node.level + 1, children: [] }));
+    if ((!node.children || node.children.length === 0) && node.level < 6) {
+      let nextLevel = node.level + 1;
+      if (node.level === 0) nextLevel = 2; // Polska -> Województwo
+      if (node.level === 2) nextLevel = 5; // Województwo -> Powiat
+      if (node.level === 5) nextLevel = 6; // Powiat -> Gmina
+
+
+      const response = await axios.get(`${API_URL}/units?level=${nextLevel}&parentId=${node.id}`);
+      const children = response.data.results.map(child => ({ ...child, level: nextLevel, children: [] }));
       setTree(prevTree => {
         const newTree = JSON.parse(JSON.stringify(prevTree)); // Deep copy
         const nodeToUpdate = findNode(newTree, node.id);


### PR DESCRIPTION
- I modified the `onNodeToggle` function to skip the 'Makroregion', 'Region', and 'Podregion' levels.
- The tree now transitions directly from 'Polska' to 'Województwo', 'Województwo' to 'Powiat', and 'Powiat' to 'Gmina'.