### PR TITLE
Fix: Fetch all units by increasing page size

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -12,7 +12,7 @@ const BDL_API_URL = 'https://bdl.stat.gov.pl/api/v1';
 
 app.get('/api/units', async (req, res) => {
     const { level = 0, parentId } = req.query;
-    let url = `${BDL_API_URL}/units?level=${level}&format=json`;
+    let url = `${BDL_API_URL}/units?level=${level}&format=json&page-size=100`;
     if (parentId) {
         url += `&parent-id=${parentId}`;
     }


### PR DESCRIPTION
- Added the `page-size=100` parameter to the API calls for fetching units
- This resolves the issue of missing units due to default API pagination