### PR TITLE
Improve layout styles for UnitPicker

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -28,3 +28,22 @@
   padding: 5px;
   cursor: pointer;
 }
+
+.unit-picker {
+  display: flex;
+  justify-content: space-between;
+  margin: 20px auto;
+  padding: 20px;
+  border: 1px solid #ccc;
+  max-width: 1000px;
+}
+
+.unit-tree,
+.dual-list {
+  width: 50%;
+  padding: 0 20px;
+}
+
+.unit-tree {
+  border-right: 1px solid #eee;
+}

--- a/client/src/components/UnitPicker.js
+++ b/client/src/components/UnitPicker.js
@@ -90,8 +90,8 @@ const UnitPicker = ({ selectedUnits, setSelectedUnits }) => {
   };
 
   return (
-    <div style={{ display: 'flex' }}>
-      <div style={{ width: '50%' }}>
+    <div className="unit-picker">
+      <div className="unit-tree">
         <h3>Dostępne jednostki</h3>
         <ul>
           {tree.map(node => (
@@ -99,7 +99,7 @@ const UnitPicker = ({ selectedUnits, setSelectedUnits }) => {
           ))}
         </ul>
       </div>
-      <div style={{ width: '50%' }}>
+      <div className="dual-list">
         <DualListBox
           options={availableUnits}
           selected={selectedUnits.map(u => u.value)}


### PR DESCRIPTION
## Summary
- create `.unit-picker`, `.unit-tree`, and `.dual-list` styles
- replace inline styles in `UnitPicker` with CSS classes

## Testing
- `npm start`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68879bff6958832fb25a07ce410bb939