### PR TITLE
Refactor UnitPicker to remove dual listbox and fix UI

### DIFF
--- a/client/src/components/UnitPicker.js
+++ b/client/src/components/UnitPicker.js
@@ -13,10 +13,10 @@ const TreeNode = ({ node, onNodeToggle, onUnitAdd }) => {
 
   return (
     <li>
-      <span onClick={handleToggle} style={{ cursor: 'pointer' }}>
-        {isOpen ? '[-]' : '[+]'} {node.name}
+      <span onClick={handleToggle} style={{ cursor: 'pointer', display: 'inline-flex', alignItems: 'center' }}>
+        <span>{isOpen ? '[-]' : '[+]'}&nbsp;{node.name}</span>
       </span>
-      <button onClick={() => onUnitAdd({ value: node.id, label: node.name })}>+</button>
+      <button onClick={() => onUnitAdd({ value: node.id, label: node.name })} style={{ marginLeft: '5px' }}>+</button>
       {isOpen && node.children && (
         <ul>
           {node.children.map(child => (


### PR DESCRIPTION
- I removed the `react-dual-listbox` component and replaced it with a single list of selected units.
- I added buttons to remove all or a single selected unit.
- I fixed an issue where the plus sign would wrap to the next line.