### PR TITLE
Add category config and frontend selection

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const cors = require('cors');
 const axios = require('axios');
+const fs = require('fs');
+const path = require('path');
 
 const app = express();
 const port = 3001;
@@ -9,6 +11,13 @@ app.use(cors());
 
 const BDL_API_KEY = '7eb6ceb7-a994-4bf0-f27f-08ddcd5a2c67';
 const BDL_API_URL = 'https://bdl.stat.gov.pl/api/v1';
+const VARIABLES = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '../config/variables.json'), 'utf8')
+);
+
+app.get('/api/variables', (req, res) => {
+    res.json(VARIABLES);
+});
 
 app.get('/api/units', async (req, res) => {
     const { level = 0, parentId } = req.query;
@@ -28,11 +37,17 @@ app.get('/api/units', async (req, res) => {
 });
 
 app.get('/api/data', async (req, res) => {
-    const { varId, unitId } = req.query;
+    const { category, varId, unitId } = req.query;
+    const variableId = varId || VARIABLES[category];
+    if (!variableId) {
+        return res.status(400).json({ error: 'Unknown variable category' });
+    }
+
     try {
-        const response = await axios.get(`${BDL_API_URL}/data/by-variable/${varId}?unit-id=${unitId}&year=2020&year=2021&year=2022&year=2023&year=2024&format=json`, {
-            headers: { 'X-ClientId': BDL_API_KEY }
-        });
+        const response = await axios.get(
+            `${BDL_API_URL}/data/by-variable/${variableId}?unit-id=${unitId}&year=2020&year=2021&year=2022&year=2023&year=2024&format=json`,
+            { headers: { 'X-ClientId': BDL_API_KEY } }
+        );
         res.json(response.data);
     } catch (error) {
         res.status(500).json({ error: 'Error fetching data' });

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -49,3 +49,7 @@
   width: 40%;
   padding: 0 20px;
 }
+
+.category-picker {
+  margin-top: 20px;
+}

--- a/config/variables.json
+++ b/config/variables.json
@@ -1,0 +1,6 @@
+{
+  "population_total": "60618",
+  "death_total": "6581",
+  "migration_total": "80122",
+  "birth_rate": "6326"
+}


### PR DESCRIPTION
## Summary
- configure variable IDs in a shared `config/variables.json`
- load these IDs server‑side and expose them at `/api/variables`
- update `/api/data` endpoint to accept category names
- allow choosing categories in the React UI and export only the selected data

## Testing
- `npm test --silent` in `client` (no tests)
- `npm test --silent` in `backend` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_6887b1858ff4832f9e1b9bb0e7381afa